### PR TITLE
Fix when new years falls on a Saturday

### DIFF
--- a/src/DateTimeExtensions/WorkingDays/CultureStrategies/EN_USHolidayStrategy.cs
+++ b/src/DateTimeExtensions/WorkingDays/CultureStrategies/EN_USHolidayStrategy.cs
@@ -33,7 +33,7 @@ namespace DateTimeExtensions.WorkingDays.CultureStrategies
         {
             this.InnerHolidays.Add(GlobalHolidays.NewYear);
             this.InnerHolidays.Add(ChristianHolidays.Christmas);
-
+            this.InnerHolidays.Add(NewYearsEve);
             this.InnerHolidays.Add(IndependenceDay);
             this.InnerHolidays.Add(GlobalHolidays.VeteransDay);
             this.InnerHolidays.Add(MartinLutherKing);
@@ -180,6 +180,20 @@ namespace DateTimeExtensions.WorkingDays.CultureStrategies
                         CountDirection.FromFirst);
                 }
                 return thanksgivingDay;
+            }
+        }
+
+        private static Holiday newYearsEve;
+
+        public static Holiday NewYearsEve
+        {
+            get
+            {
+                if (newYearsEve == null)
+                {
+                    newYearsEve = new NewYearEveFridayOnly();
+                }
+                return newYearsEve;
             }
         }
     }

--- a/src/DateTimeExtensions/WorkingDays/NewYearEveFridayOnly.cs
+++ b/src/DateTimeExtensions/WorkingDays/NewYearEveFridayOnly.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace DateTimeExtensions.WorkingDays
+{
+    public class NewYearEveFridayOnly : FixedHoliday
+    {
+        public NewYearEveFridayOnly() : base(GlobalHolidays.NewYearsEve.Name, 12, 31)
+        {
+        }
+
+        public override DateTime? GetInstance(int year)
+        {
+            DateTime? date = base.GetInstance(year);
+            if (date.HasValue && date.Value.DayOfWeek == DayOfWeek.Friday)
+            {
+                return date;
+            }
+            return null;
+        }
+    }
+}

--- a/tests/DateTimeExtensions.Tests/EnUsHolidaysTests.cs
+++ b/tests/DateTimeExtensions.Tests/EnUsHolidaysTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using NUnit.Framework;
+using DateTimeExtensions.WorkingDays;
+
+namespace DateTimeExtensions.Tests
+{
+    [TestFixture]
+    public class EnUsHolidaysTests
+    {
+        private readonly WorkingDayCultureInfo workingDayCultureInfo = new WorkingDayCultureInfo("en-US");
+
+        [Test]
+        public void NewYearsDay_FallsOnSaturday_ExpectFridayHoliday()
+        {
+            var dateOnGregorian = new DateTime(2004, 12, 31);
+            AssertIsHoliday(workingDayCultureInfo, dateOnGregorian);
+            dateOnGregorian = new DateTime(2010, 12, 31);
+            AssertIsHoliday(workingDayCultureInfo, dateOnGregorian);
+            dateOnGregorian = new DateTime(2021, 12, 31);
+            AssertIsHoliday(workingDayCultureInfo, dateOnGregorian);
+        }
+
+        [Test]
+        public void NewYearsDay_FallsNotOnWeekend_Expect31stNotHoliday()
+        {
+            var dateOnGregorian = new DateTime(2008, 12, 31);
+            AssertIsNotHoliday(workingDayCultureInfo, dateOnGregorian);
+            dateOnGregorian = new DateTime(2011, 12, 31);
+            AssertIsNotHoliday(workingDayCultureInfo, dateOnGregorian);
+        }
+
+        private void AssertIsHoliday(IWorkingDayCultureInfo workingDayCultureInfo, DateTime dateOnGregorian)
+        {
+            var isHoliday = workingDayCultureInfo.IsHoliday(dateOnGregorian);
+            Assert.IsTrue(isHoliday);
+        }
+
+        private void AssertIsNotHoliday(IWorkingDayCultureInfo workingDayCultureInfo, DateTime dateOnGregorian)
+        {
+            var isHoliday = workingDayCultureInfo.IsHoliday(dateOnGregorian);
+            Assert.IsFalse(isHoliday);
+        }
+    }
+}


### PR DESCRIPTION
This PR has a fix for when New Years Day falls on a Saturday in the US, then the Friday before (New Year Eve)  should be a holiday.