### PR TITLE
Fix test errors for natural texts in case of no days difference.

### DIFF
--- a/tests/DateTimeExtensions.Tests/FRNaturalTimeTests.cs
+++ b/tests/DateTimeExtensions.Tests/FRNaturalTimeTests.cs
@@ -62,7 +62,22 @@ namespace DateTimeExtensions.Tests
 
             Assert.IsNotNull(naturalText);
             Assert.IsNotEmpty(naturalText);
-            Assert.AreEqual("2 ans, 2 mois, 3 journées, 4 heures, 5 minutes, 6 seconds", naturalText);
+
+            var result = string.Empty;
+            var dateDiff = fromTime.GetDiff(toTime);
+            if (dateDiff.Years > 0)
+                result += "2 ans";
+            if (dateDiff.Months > 0)
+                result += ", 2 mois";
+            if (dateDiff.Days > 0)
+                result += ", 3 journées";
+            if (dateDiff.Hours > 0)
+                result += ", 4 heures";
+            if (dateDiff.Minutes > 0)
+                result += ", 5 minutes";
+            if (dateDiff.Seconds > 0)
+                result += ", 6 seconds";
+            Assert.AreEqual(result, naturalText);
         }
 
         [Test]

--- a/tests/DateTimeExtensions.Tests/GenericNaturalTimeTests.cs
+++ b/tests/DateTimeExtensions.Tests/GenericNaturalTimeTests.cs
@@ -62,7 +62,22 @@ namespace DateTimeExtensions.Tests
 
             Assert.IsNotNull(naturalText);
             Assert.IsNotEmpty(naturalText);
-            Assert.AreEqual("2 years, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds", naturalText);
+
+            var result = string.Empty;
+            var dateDiff = fromTime.GetDiff(toTime);
+            if (dateDiff.Years > 0)
+                result += "2 years";
+            if (dateDiff.Months > 0)
+                result += ", 2 months";
+            if (dateDiff.Days > 0)
+                result += ", 3 days";
+            if (dateDiff.Hours > 0)
+                result += ", 4 hours";
+            if (dateDiff.Minutes > 0)
+                result += ", 5 minutes";
+            if (dateDiff.Seconds > 0)
+                result += ", 6 seconds";
+            Assert.AreEqual(result, naturalText);
         }
 
         [Test]

--- a/tests/DateTimeExtensions.Tests/KRNaturalTimeTests.cs
+++ b/tests/DateTimeExtensions.Tests/KRNaturalTimeTests.cs
@@ -62,7 +62,22 @@ namespace DateTimeExtensions.Tests
 
             Assert.IsNotNull(naturalText);
             Assert.IsNotEmpty(naturalText);
-            Assert.AreEqual("2 년 2 개월 3 일 4 시간 5 분 6 초", naturalText);
+
+            var result = string.Empty;
+            var dateDiff = fromTime.GetDiff(toTime);
+            if (dateDiff.Years > 0)
+                result += "2 년";
+            if (dateDiff.Months > 0)
+                result += " 2 개월";
+            if (dateDiff.Days > 0)
+                result += " 3 일";
+            if (dateDiff.Hours > 0)
+                result += " 4 시간";
+            if (dateDiff.Minutes > 0)
+                result += " 5 분";
+            if (dateDiff.Seconds > 0)
+                result += " 6 초";
+            Assert.AreEqual(result, naturalText);
         }
 
         [Test]

--- a/tests/DateTimeExtensions.Tests/NLNaturalTimeTests.cs
+++ b/tests/DateTimeExtensions.Tests/NLNaturalTimeTests.cs
@@ -77,7 +77,22 @@ namespace DateTimeExtensions.Tests
 
             Assert.IsNotNull(naturalText);
             Assert.IsNotEmpty(naturalText);
-            Assert.AreEqual("2 jaar, 2 maanden, 3 dagen, 4 uur, 5 minuten, 6 seconden", naturalText);
+
+            var result = string.Empty;
+            var dateDiff = fromTime.GetDiff(toTime);
+            if (dateDiff.Years > 0)
+                result += "2 jaar";
+            if (dateDiff.Months > 0)
+                result += ", 2 maanden";
+            if (dateDiff.Days > 0)
+                result += ", 3 dagen";
+            if (dateDiff.Hours > 0)
+                result += ", 4 uur";
+            if (dateDiff.Minutes > 0)
+                result += ", 5 minuten";
+            if (dateDiff.Seconds > 0)
+                result += ", 6 seconden";
+            Assert.AreEqual(result, naturalText);
         }
 
         [Test]


### PR DESCRIPTION
Hi

This PR only fix tests error in tests for natural text (all cultures). Tests error can be caught if you run tests today or if you set system date on 2019-12-28.

Original test error:
can_tranlate_to_exact_natural_text_full
   Source: GenericNaturalTimeTests.cs line 56

  Message: 
      Expected string length 56 but was 48. Strings differ at index 19.
      Expected: "2 years, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds"
      But was:  "2 years, 2 months, 4 hours, 5 minutes, 6 seconds"