### PR TITLE
Make EasterBasedHoliday threadsafe

### DIFF
--- a/src/DateTimeExtensions/WorkingDays/EasterBasedHoliday.cs
+++ b/src/DateTimeExtensions/WorkingDays/EasterBasedHoliday.cs
@@ -29,7 +29,7 @@ namespace DateTimeExtensions.WorkingDays
     public class EasterBasedHoliday : Holiday
     {
         private int daysOffset;
-        private ConcurrentLazyDictionary<int, DateTime> dayCache;
+        private readonly ConcurrentLazyDictionary<int, DateTime> dayCache;
 
         public EasterBasedHoliday(string name, int daysOffset)
             : base(name)

--- a/src/DateTimeExtensions/WorkingDays/EasterBasedHoliday.cs
+++ b/src/DateTimeExtensions/WorkingDays/EasterBasedHoliday.cs
@@ -18,6 +18,7 @@
 
 #endregion
 
+using DateTimeExtensions.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,25 +29,18 @@ namespace DateTimeExtensions.WorkingDays
     public class EasterBasedHoliday : Holiday
     {
         private int daysOffset;
-        private IDictionary<int, DateTime> dayCache;
+        private ConcurrentLazyDictionary<int, DateTime> dayCache;
 
         public EasterBasedHoliday(string name, int daysOffset)
             : base(name)
         {
             this.daysOffset = daysOffset;
-            dayCache = new Dictionary<int, DateTime>();
+            dayCache = new ConcurrentLazyDictionary<int, DateTime>();
         }
 
         public override DateTime? GetInstance(int year)
         {
-            if (dayCache.ContainsKey(year))
-            {
-                return dayCache[year];
-            }
-            var easter = EasterCalculator.CalculateEasterDate(year);
-            var date = easter.AddDays(daysOffset);
-            dayCache.Add(year, date);
-            return date;
+            return dayCache.GetOrAdd(year, () => EasterCalculator.CalculateEasterDate(year).AddDays(daysOffset));
         }
 
         public override bool IsInstanceOf(DateTime date)
@@ -57,22 +51,16 @@ namespace DateTimeExtensions.WorkingDays
 
         public static class EasterCalculator
         {
-            private static IDictionary<int, DateTime> easterPerYear;
+            private static ConcurrentLazyDictionary<int, DateTime> easterPerYear;
 
             static EasterCalculator()
             {
-                easterPerYear = new Dictionary<int, DateTime>();
+                easterPerYear = new ConcurrentLazyDictionary<int, DateTime>();
             }
 
             public static DateTime CalculateEasterDate(int year)
             {
-                if (easterPerYear.ContainsKey(year))
-                {
-                    return easterPerYear[year];
-                }
-                var easter = GetEasterDate(year);
-                easterPerYear.Add(year, easter);
-                return easter;
+                return easterPerYear.GetOrAdd(year, () => GetEasterDate(year));
             }
 
             //Algoritm downloaded from http://tiagoe.blogspot.com/2007/10/easter-calculation-in-c.html

--- a/tests/DateTimeExtensions.Tests/ThreadSafeTests.cs
+++ b/tests/DateTimeExtensions.Tests/ThreadSafeTests.cs
@@ -21,5 +21,27 @@ namespace DateTimeExtensions.Tests
             //Act
             Parallel.ForEach(Enumerable.Range(1,10), (i) => startDate.AddWorkingDays(i, culture));
         }
+
+        [Test]
+        public void CheckEaster_MultipleThreads()
+        {
+            Parallel.ForEach(Enumerable.Range(1, 10), (i) => ascencion_is_39_days_after_easter());
+        }
+
+        private void ascencion_is_39_days_after_easter()
+        {
+            var year = 2025;
+            var easterDate = new DateTime(2025, 4, 20);
+
+            var ascencionHoliday = ChristianHolidays.Ascension;
+            var ascencion = ascencionHoliday.GetInstance(year);
+            Assert.IsTrue(ascencion.HasValue);
+            Assert.AreEqual(DayOfWeek.Thursday, ascencion.Value.DayOfWeek);
+
+            //source: http://en.wikipedia.org/wiki/Ascension_Day
+            // Ascension Day is traditionally celebrated on a Thursday, the fortieth day of Easter
+            // again, easter day is included
+            Assert.AreEqual(easterDate.AddDays(39), ascencion.Value);
+        }
     }
 }


### PR DESCRIPTION
EasterBasedHoliday still uses Dictionary that causes "key already exists" exception in multi-threaded applications. (see the new test.) Using ConcurrentLazyDictionary fixes the issue.
