### PR TITLE
Fix version conflicts caused by PR#107

### DIFF
--- a/src/DateTimeExtensions/DateTimeExtensions.csproj
+++ b/src/DateTimeExtensions/DateTimeExtensions.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.1" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.Globalization.Calendars" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump System.Text.RegularExpressions from 4.3.0 to 4.3.1. [(PR#107)](https://github.com/joaomatossilva/DateTimeExtensions/pull/107).
Hope this fix can help you.

Best regards,
sucrose