### PR TITLE
Update EN_ZAHolidayStrategy.cs

### DIFF
--- a/src/DateTimeExtensions/WorkingDays/CultureStrategies/EN_ZAHolidayStrategy.cs
+++ b/src/DateTimeExtensions/WorkingDays/CultureStrategies/EN_ZAHolidayStrategy.cs
@@ -50,16 +50,21 @@ namespace DateTimeExtensions.WorkingDays.CultureStrategies
             IDictionary<DateTime, Holiday> holidayMap = new Dictionary<DateTime, Holiday>();
             foreach (var innerHoliday in InnerHolidays)
             {
-                var date = innerHoliday.GetInstance(year);
-                if (date.HasValue)
-                {
-                    holidayMap.Add(date.Value, innerHoliday);
-                    //if the holiday is a sunday, the holiday is observed on next monday
-                    if (date.Value.DayOfWeek == DayOfWeek.Sunday)
+                 var date = innerHoliday.GetInstance(year);
+                    if (date.HasValue)
                     {
-                        holidayMap.AddIfInexistent(date.Value.AddDays(1), innerHoliday);
+                        if (holidayMap.ContainsKey(date.Value))
+                            // Check to see if holiday falling on the Sunday then moves to the monday, and there is another holiday scheduled for the monday
+                            // Update the Holiday Name of the Monday
+                            holidayMap[date.Value] = innerHoliday;
+                        else
+                            holidayMap.Add(date.Value, innerHoliday);
+                            //if the holiday is a sunday, the holiday is observed on next monday
+                            if (date.Value.DayOfWeek == DayOfWeek.Sunday)
+                            {
+                                holidayMap.AddIfInexistent(date.Value.AddDays(1), innerHoliday);
+                            }
                     }
-                }
             }
             return holidayMap;
         }


### PR DESCRIPTION
Error occurs where the key already exists, this happens with the 26th December, as the 25th in on a Sunday, the holiday if forfeited if the next Day is also a public holiday as in this case. SO we need to check if this occurs and if it does we just update the value of the key to the correct name. This was you will not end up with two Christmas's etc...