### PR TITLE
Fix unit test for en-JM culture

### DIFF
--- a/tests/DateTimeExtensions.Tests/enJMHolidaysTests.cs
+++ b/tests/DateTimeExtensions.Tests/enJMHolidaysTests.cs
@@ -8,17 +8,34 @@ namespace DateTimeExtensions.Tests
     internal class enJMHolidaysTests
     {
         private readonly WorkingDayCultureInfo dateTimeCulture = new WorkingDayCultureInfo("en-JM", "Jamaica");
+
         [Test]
-        public void SundayChristmass2022()
-        {//Holiday's falling on Sunday are observed on the following monday.
-            //boxing day was the 26th, a monday, which would result in a clash, hence the clashing holiday would be observed on the following day (Tuesday)
-            var date = new DateTime(2022, 12, 25);
-            TestHoliday(dateTimeCulture, date);
-        }
-        private void TestHoliday(IWorkingDayCultureInfo workingDayCultureInfo, DateTime dateOnGregorian)
+        public void BoxingDay_2022_is_observed_tuesday()
         {
-            var isHoliday = workingDayCultureInfo.IsHoliday(dateOnGregorian);
-            Assert.IsTrue(isHoliday);
+            //Holiday's falling on Sunday are observed on the following monday.
+            //boxing day was the 26th, a monday, which would result in a clash, hence the clashing holiday would be observed on the following day (Tuesday)
+            var boxingDay = new DateTime(2022, 12, 26);
+            var boxingDayObserved = boxingDay.AddDays(1);
+            Assert.IsTrue(boxingDayObserved.IsHoliday(dateTimeCulture));
+        }
+
+        [Test]
+        public void Christmas_2022_sunday_is_observed_monday()
+        {
+            // Holiday's falling on Sunday are observed on the following monday.
+            // Christmas on a sunday should not be a holiday.
+            var christmasSunday = new DateTime(2022, 12, 25);
+            var christmasObserved = christmasSunday.AddDays(1);
+            Assert.IsTrue(christmasObserved.IsHoliday(dateTimeCulture));
+        }
+
+        [Test]
+        public void Christmas_sunday_not_a_holiday()
+        {
+            // Holiday's falling on Sunday are observed on the following monday.
+            // Christmas on a sunday should not be a holiday.
+            var christmasSunday = new DateTime(2022, 12, 25);
+            Assert.IsFalse(christmasSunday.IsHoliday(dateTimeCulture));
         }
     }
 }


### PR DESCRIPTION
On running the unit tests the specific test for en-JM culture fails.

```
 SundayChristmass2022
   Source: enJMHolidaysTests.cs line 11
   Duration: 75 ms

  Message: 
  Expected: True
  But was:  False


  Stack Trace: 
enJMHolidaysTests.TestHoliday(IWorkingDayCultureInfo workingDayCultureInfo, DateTime dateOnGregorian) line 20
enJMHolidaysTests.SundayChristmass2022() line 15
1)    at DateTimeExtensions.Tests.enJMHolidaysTests.TestHoliday(IWorkingDayCultureInfo workingDayCultureInfo, DateTime dateOnGregorian) in D:\Devops\DateTimeExtensions\tests\DateTimeExtensions.Tests\enJMHolidaysTests.cs:line 20
enJMHolidaysTests.SundayChristmass2022() line 15
```

On investigation I found that the unit test assumed that christmas 2022 (Sunday) should be a holiday. But the comments on the unit test specify that the holiday is observed on the next weekday (Monday).

I rewrote the unit tests to match this description. And added separate test to verify boxing day is also moved from monday to tuesday.