### PR TITLE
Add IsWithinBusinessHours Extension Method

### DIFF
--- a/DateTimeExtensions.Tests.cs
+++ b/DateTimeExtensions.Tests.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using System;
+
+namespace DateTimeExtensions.Tests
+{
+    [TestFixture]
+    public class DateTimeExtensionsTests
+    {
+        [Test]
+        public void IsWithinBusinessHours_ShouldReturnTrue_WhenWithinHours()
+        {
+            var dateTime = new DateTime(2024, 8, 5, 10, 0, 0); // 10:00 AM
+            var startTime = new TimeSpan(9, 0, 0);
+            var endTime = new TimeSpan(17, 0, 0);
+
+            var result = dateTime.IsWithinBusinessHours(startTime, endTime);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsWithinBusinessHours_ShouldReturnFalse_WhenOutsideHours()
+        {
+            var dateTime = new DateTime(2024, 8, 5, 18, 0, 0); // 6:00 PM
+            var startTime = new TimeSpan(9, 0, 0);
+            var endTime = new TimeSpan(17, 0, 0);
+
+            var result = dateTime.IsWithinBusinessHours(startTime, endTime);
+
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/DateTimeExtensions.cs
+++ b/DateTimeExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace DateTimeExtensions
+{
+    public static class DateTimeExtensions
+    {
+        public static bool IsWithinBusinessHours(this DateTime dateTime, TimeSpan startTime, TimeSpan endTime)
+        {
+            var timeOfDay = dateTime.TimeOfDay;
+            return timeOfDay >= startTime && timeOfDay <= endTime;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces the `IsWithinBusinessHours` extension method for the `DateTime` class. This method allows checking if a given `DateTime` falls within a specified range of business hours. 

**Changes:**
- Added `IsWithinBusinessHours` method to `DateTimeExtensions.cs`.
- Added tests for the new method.

**Example Usage:**
```csharp
DateTime now = DateTime.Now;
bool isWithinBusinessHours = now.IsWithinBusinessHours(new TimeSpan(9, 0, 0), new TimeSpan(17, 0, 0));
